### PR TITLE
Optimize helper routines

### DIFF
--- a/sys/Driver.cpp
+++ b/sys/Driver.cpp
@@ -606,15 +606,20 @@ void Util_DumpAsHex(PCSTR Prefix, PVOID Buffer, ULONG BufferLength)
 		dumpBufferLength,
 		'1234'
 	));
-	if (dumpBuffer)
-	{
+        if (dumpBuffer)
+        {
 
-		RtlZeroMemory(dumpBuffer, dumpBufferLength);
+                RtlZeroMemory(dumpBuffer, dumpBufferLength);
 
-		for (ULONG i = 0; i < BufferLength; i++)
-		{
-			sprintf(&dumpBuffer[i * 2], "%02X", static_cast<PUCHAR>(Buffer)[i]);
-		}
+                static const CHAR hex[] = "0123456789ABCDEF";
+
+                for (ULONG i = 0; i < BufferLength; i++)
+                {
+                        const UCHAR byte = static_cast<PUCHAR>(Buffer)[i];
+                        dumpBuffer[i * 2] = hex[byte >> 4];
+                        dumpBuffer[i * 2 + 1] = hex[byte & 0xF];
+                }
+                dumpBuffer[BufferLength * 2] = '\0';
 
 		TraceVerbose(TRACE_BUSPDO,
 			"%s - Buffer length: %04d, buffer content: %s\n",

--- a/sys/Ds4Pdo.cpp
+++ b/sys/Ds4Pdo.cpp
@@ -1216,23 +1216,20 @@ NTSTATUS ViGEm::Bus::Targets::EmulationTargetDS4::SubmitReportImpl(PVOID NewRepo
 
 VOID ViGEm::Bus::Targets::EmulationTargetDS4::ReverseByteArray(PUCHAR Array, INT Length)
 {
-	const auto s = static_cast<PUCHAR>(ExAllocatePoolZero(
-		NonPagedPoolNx,
-		sizeof(UCHAR) * Length,
-		'U4SD'
-	));
-	INT c, d;
+        if (Array == nullptr || Length <= 1)
+                return;
 
-	if (s == nullptr)
-		return;
+        INT start = 0;
+        INT end = Length - 1;
 
-	for (c = Length - 1, d = 0; c >= 0; c--, d++)
-		*(s + d) = *(Array + c);
-
-	for (c = 0; c < Length; c++)
-		*(Array + c) = *(s + c);
-
-	ExFreePoolWithTag(s, 'U4SD');
+        while (start < end)
+        {
+                const UCHAR tmp = Array[start];
+                Array[start] = Array[end];
+                Array[end] = tmp;
+                start++;
+                end--;
+        }
 }
 
 VOID ViGEm::Bus::Targets::EmulationTargetDS4::GenerateRandomMacAddress(PMAC_ADDRESS Address)

--- a/sys/EmulationTargetPDO.cpp
+++ b/sys/EmulationTargetPDO.cpp
@@ -733,15 +733,20 @@ VOID ViGEm::Bus::Core::EmulationTargetPDO::DumpAsHex(PCSTR Prefix, PVOID Buffer,
 		dumpBufferLength,
 		'1234'
 	));
-	if (dumpBuffer)
-	{
+        if (dumpBuffer)
+        {
 
-		RtlZeroMemory(dumpBuffer, dumpBufferLength);
+                RtlZeroMemory(dumpBuffer, dumpBufferLength);
 
-		for (ULONG i = 0; i < BufferLength; i++)
-		{
-			sprintf(&dumpBuffer[i * 2], "%02X", static_cast<PUCHAR>(Buffer)[i]);
-		}
+                static const CHAR hex[] = "0123456789ABCDEF";
+
+                for (ULONG i = 0; i < BufferLength; i++)
+                {
+                        const UCHAR byte = static_cast<PUCHAR>(Buffer)[i];
+                        dumpBuffer[i * 2] = hex[byte >> 4];
+                        dumpBuffer[i * 2 + 1] = hex[byte & 0xF];
+                }
+                dumpBuffer[BufferLength * 2] = '\0';
 
 		TraceVerbose(TRACE_BUSPDO,
 			"%s - Buffer length: %04d, buffer content: %s\n",


### PR DESCRIPTION
## Summary
- reverse byte arrays in place
- simplify hex dumping logic for less overhead

## Testing
- `./build.sh` *(fails: blocked network download)*

------
https://chatgpt.com/codex/tasks/task_e_685488c85a048329b57f402f8a0a97be