### PR TITLE
Fix outdated configurations

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/sys/Driver.cpp
+++ b/sys/Driver.cpp
@@ -611,10 +611,10 @@ void Util_DumpAsHex(PCSTR Prefix, PVOID Buffer, ULONG BufferLength)
 
 		RtlZeroMemory(dumpBuffer, dumpBufferLength);
 
-		for (ULONG i = 0; i < BufferLength; i++)
-		{
-			sprintf(&dumpBuffer[i * 2], "%02X", static_cast<PUCHAR>(Buffer)[i]);
-		}
+                for (ULONG i = 0; i < BufferLength; i++)
+                {
+                        sprintf_s(&dumpBuffer[i * 2], 3, "%02X", static_cast<PUCHAR>(Buffer)[i]);
+                }
 
 		TraceVerbose(TRACE_BUSPDO,
 			"%s - Buffer length: %04d, buffer content: %s\n",

--- a/sys/EmulationTargetPDO.cpp
+++ b/sys/EmulationTargetPDO.cpp
@@ -738,10 +738,10 @@ VOID ViGEm::Bus::Core::EmulationTargetPDO::DumpAsHex(PCSTR Prefix, PVOID Buffer,
 
 		RtlZeroMemory(dumpBuffer, dumpBufferLength);
 
-		for (ULONG i = 0; i < BufferLength; i++)
-		{
-			sprintf(&dumpBuffer[i * 2], "%02X", static_cast<PUCHAR>(Buffer)[i]);
-		}
+                for (ULONG i = 0; i < BufferLength; i++)
+                {
+                        sprintf_s(&dumpBuffer[i * 2], 3, "%02X", static_cast<PUCHAR>(Buffer)[i]);
+                }
 
 		TraceVerbose(TRACE_BUSPDO,
 			"%s - Buffer length: %04d, buffer content: %s\n",

--- a/sys/ViGEmBus.vcxproj
+++ b/sys/ViGEmBus.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -63,7 +63,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{040101B0-EE5C-4EF1-99EE-9F81C795C001}</ProjectGuid>
     <TemplateGuid>{8c0e3d8b-df43-455b-815a-4a0e72973bc6}</TemplateGuid>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <Configuration>Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">Win32</Platform>


### PR DESCRIPTION
## Summary
- update Nuke build target to net8.0
- bump driver vcxproj tools version and framework
- use safer `sprintf_s` helper

## Testing
- `./build.sh --help` *(fails: missing .NET runtime)*

------
https://chatgpt.com/codex/tasks/task_e_685488d9293c8329b7234aa9a1087223